### PR TITLE
4_CSVインポートの準備

### DIFF
--- a/lib/import.rb
+++ b/lib/import.rb
@@ -1,0 +1,20 @@
+# CSVファイルを扱うときは次が必要
+require "csv"
+
+class Import
+  def self.csv_data(path:)
+    # CSVファイルの（１行目をキーとして）各行のデータを配列に格納する
+    # CSVファイルのカラム名と，テーブルのカラム名を一致させておく必要がある
+    # row は CSV::Row クラスである。これはモデルの引数として渡せないのでハッシュに変換しておく。
+    list = []
+    CSV.foreach(path, headers: true) { |row| list << row.to_h }
+    list << {}
+  end
+  puts "インポート開始"
+  hoge.create!(list)
+  puts "インポートに成功しました"
+rescue ActiveModel::UnknownAttributeError => invalid
+
+  puts "インポートに失敗しました:#{invalid}"
+
+end

--- a/lib/import.rb
+++ b/lib/import.rb
@@ -8,13 +8,6 @@ class Import
     # row は CSV::Row クラスである。これはモデルの引数として渡せないのでハッシュに変換しておく。
     list = []
     CSV.foreach(path, headers: true) { |row| list << row.to_h }
-    list << {}
+    list
   end
-  puts "インポート開始"
-  hoge.create!(list)
-  puts "インポートに成功しました"
-rescue ActiveModel::UnknownAttributeError => invalid
-
-  puts "インポートに失敗しました:#{invalid}"
-
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,0 +1,10 @@
+require "import.rb"
+
+namespace :import_csv do
+  desc "hogeデータのインポート"
+
+  task: :environment do
+    hoge.import(path 'db/csv_data/hogehoge')
+  end
+
+end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,1 +1,11 @@
 require "import"
+
+namespace :import_csv do
+  # 起動コマンド記載欄
+  desc "hogeデータのインポート"
+
+  task hoge: :environment do
+    hoge.import(path: 'db/csv_data/hogehoge')
+  end
+
+end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,10 +1,1 @@
 require "import"
-
-namespace :import_csv do
-  desc "hogeデータのインポート"
-
-  task: :environment do
-    hoge.import(path 'db/csv_data/hogehoge')
-  end
-
-end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,4 +1,4 @@
-require "import.rb"
+require "import"
 
 namespace :import_csv do
   desc "hogeデータのインポート"


### PR DESCRIPTION
## 内容

- `import.rb`をlibディレクトリに追加
- `db/csv_data`ディレクトリを作成
- `import_csv`のrakeタスクを作成
- `lib/tasks/import_csv.rake`から`import.rb` の読み込みを許可

### 参考資料

- [4_CSVインポートの準備](https://trello.com/c/cQdfOGYK/17-4csv%E3%82%A4%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%88%E3%81%AE%E6%BA%96%E5%82%99)

- [逆転教材 CSVインポート](https://arcane-gorge-21903.herokuapp.com/texts/217)

- [逆転教材 Rakeタスク](https://arcane-gorge-21903.herokuapp.com/texts/218)