### PR TITLE
11_ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,10 +3,26 @@
  *= require_self
  */
 
- @import "bootstrap/scss/bootstrap";
- 
+@import "bootstrap/scss/bootstrap";
+
 .base-container {
   max-width: 992px;
   margin: 0 auto;
   padding: 1rem;
 }
+
+.base-color {
+  background-color: #5D98FF;
+}
+
+@media screen and (min-width: 992px){
+.navbar {
+  font-size: 0.6rem;
+  margin: 0 auto;
+  width: var(--breakpoint-lg);
+  }
+}
+
+
+
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,7 @@
 
 @media screen and (min-width: 992px){
 .navbar {
-  font-size: 0.6rem;
+  font-size: 0.8rem;
   margin: 0 auto;
   width: var(--breakpoint-lg);
   }

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -42,15 +42,16 @@
           <li class="nav-item">
             <a class="nav-item nav-link active" href="#">アカウント編集</a>
           </li>
-          <li class="nav-item">
-            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-          </li>
-          <li class="nav-item">
+        <li class="nav-item">
+          <% if user_signed_in? %>
             <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
-          </li>
+          <% else %>
+            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+          <% end %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+        </li>
       </ul>
     </div>
   </nav>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -41,17 +41,17 @@
         </li>
         <% if user_signed_in? %>
           <li class="nav-item">
-            <a class="nav-item nav-link active" href="#">アカウント編集</a>
+            <%= link_to "アカウント編集", edit_user_registration_path, method: :get, class: "nav-item nav-link active" %>
           </li>
           <li class="nav-item">
-              <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
           </li>
         <% else %>
           <li class="nav-item">
-              <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
           </li>
           <li class="nav-item">
-              <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+            <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
           </li>
         <% end %>
       </ul>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -39,20 +39,20 @@
         <li class="nav-item">
           <a class="nav-item nav-link active" href="#">LINE@</a>
         </li>
+        <% if user_signed_in? %>
           <li class="nav-item">
             <a class="nav-item nav-link active" href="#">アカウント編集</a>
           </li>
-          <% if user_signed_in? %>
-        <li class="nav-item">
-            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
-        </li>
-          <% else %>
-        <li class="nav-item">
-            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
-            <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
-        </li>
+          <li class="nav-item">
+              <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
+          </li>
+        <% else %>
+          <li class="nav-item">
+              <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+          </li>
+          <li class="nav-item">
+              <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -42,16 +42,18 @@
           <li class="nav-item">
             <a class="nav-item nav-link active" href="#">アカウント編集</a>
           </li>
-        <li class="nav-item">
           <% if user_signed_in? %>
+        <li class="nav-item">
             <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
+        </li>
           <% else %>
+        <li class="nav-item">
             <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-          <% end %>
         </li>
         <li class="nav-item">
-          <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+            <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
         </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,13 +1,57 @@
-<nav class="navbar navbar-expand-sm navbar-dark bg-primary fixed-top">
-  <span class="navbar-brand">やんばるCODE</span>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-    <div class="navbar-nav">
-      <%= link_to "新規登録", new_user_registration_path %>
-      <%= link_to "ログイン", new_user_session_path %>
-      <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+<section class="fixed-top base-color ">
+  <nav class="navbar navbar-expand-lg navbar-dark">
+    <a class="navbar-brand" href="/">やんばるCODE</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item active dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Rails
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">Ruby/Rails教材</a>
+            <%= link_to "動画教材", movies_path, class: "dropdown-item" %>
+            <a class="dropdown-item" href="#">AWS講座</a>
+            <a class="dropdown-item" href="#">ライブコーディング</a>
+            <a class="dropdown-item" href="#">質問集</a>
+          </div>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">PHP講座</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">対談</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">情報発信</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">動画編集講座</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">ライティング講座</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">マネタイズ講座</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-item nav-link active" href="#">LINE@</a>
+        </li>
+          <li class="nav-item">
+            <a class="nav-item nav-link active" href="#">アカウント編集</a>
+          </li>
+          <li class="nav-item">
+            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+          </li>
+      </ul>
     </div>
-  </div>
-</nav>
+  </nav>
+</section>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,13 @@
+<nav class="navbar navbar-expand-sm navbar-dark bg-primary fixed-top">
+  <span class="navbar-brand">やんばるCODE</span>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+    <div class="navbar-nav">
+      <%= link_to "新規登録", new_user_registration_path %>
+      <%= link_to "ログイン", new_user_session_path %>
+      <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,11 +10,11 @@
   </head>
   <body>
     <header>
+      <%= render 'layouts/navbar' %>
     </header>
     <main>
       <div class="base-container">
-      <%= render 'layouts/navbar' %>
-      <%= yield %>
+        <%= yield %>
       </div>
     </main>
     <footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,13 +13,7 @@
     </header>
     <main>
       <div class="base-container">
-      <%# ログイン・ログアウト表示追加 %>
-      <% if user_signed_in? %>
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-      <% else %>
-        <%= link_to "ログイン", new_user_session_path %>
-        <%= link_to "新規登録", new_user_registration_path %>
-      <% end %>
+      <%= render 'layouts/navbar' %>
       <%= yield %>
       </div>
     </main>


### PR DESCRIPTION
## 内容

- Bootstrapを使い，逆転教材のナビバーに近いものを作成

    - 部分テンプレートを作成　`_navbar.html.erb`
    - 「タスク6」で作成された「新規登録・ログイン・ログアウトなどのリンク」を削除
    - 「新規登録」のリンクを追加
    - 「新規登録」「ログイン」「ログアウト」と，「動画教材」ページのみリンクを有効にし，他は「#」に設定

### 参考資料

- [11_ナビバーの実装](https://trello.com/c/yzkaEgg9/9-11%E3%83%8A%E3%83%93%E3%83%90%E3%83%BC%E3%81%AE%E5%AE%9F%E8%A3%85)

- [逆転教材](https://arcane-gorge-21903.herokuapp.com/)

- [逆転教材 Bootstrapの導入](https://arcane-gorge-21903.herokuapp.com/texts/216)

- [resources を使ったCRUD処理の実装](https://arcane-gorge-21903.herokuapp.com/texts/214)