### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,10 @@ gem 'activeadmin'
 #スタイル修正用のgemを追加
 gem 'devise-bootstrap-views'
 
+#markdownとシンタックスハイライトを追加
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0.0)
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,9 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.order(id: :asc)
   end
+
+  def show
+    @aws_texts = AwsText.find(params[:id])
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+      def block_code(code, language)
+          language = language.split(':')[0] if language.present?
+
+          case language.to_s
+          when 'rb'
+              lang = :ruby
+          when 'yml'
+              lang = :yaml
+          when 'css'
+              lang = :css
+          when 'html'
+              lang = :html
+          when ''
+              lang = :md
+          else
+              lang = language
+          end
+
+          CodeRay.scan(code, lang).div
+      end
+  end
+
+  def markdown(text)
+      html_render = HTMLwithCoderay.new(
+        filter_html: true,
+        hard_wrap: true,
+        link_attributes: { rel: 'nofollow', target: "_blank" }
+      )
+      options = {
+          autolink: true,
+          space_after_headers: true,
+          no_intra_emphasis: true,
+          fenced_code_blocks: true,
+          tables: true,
+          hard_wrap: true,
+          xhtml: true,
+          lax_html_blocks: true,
+          strikethrough: true
+      }
+      markdown = Redcarpet::Markdown.new(html_render, options)
+      markdown.render(text)
+  end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -20,7 +20,7 @@
             <%= i %>
             </td>
             <td>
-              <%= aws_text.title %>
+              <%= link_to(aws_text.title, "/aws_texts/#{aws_text.id}") %>
             </td>
           </tr>
         <% end %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -20,7 +20,7 @@
             <%= i %>
             </td>
             <td>
-              <%= link_to(aws_text.title, "/aws_texts/#{aws_text.id}") %>
+              <%= link_to(aws_text.title, aws_text) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,5 @@
+<h2>
+  <%= @aws_texts.title%>
+</h2>
+
+<%= markdown(@aws_texts.content).html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "movies#index"
   resources :movies
-  resources :aws_texts, only: :index
-  get "aws_texts/:id" => "aws_texts#show"
+  resources :aws_texts, only: [:index, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   root "movies#index"
   resources :movies
   resources :aws_texts, only: :index
-
+  get "aws_texts/:id" => "aws_texts#show"
 end


### PR DESCRIPTION
内容
・詳細ページの作成
・一覧ページの「内容」から詳細ページに移動できるようにリンクを作成
・Markdownの導入

参考資料
https://arcane-gorge-21903.herokuapp.com/texts/224
https://arcane-gorge-21903.herokuapp.com/texts/189