### PR TITLE
24_AWSテキスト教材別ウインドウで表示

### DIFF
--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -20,7 +20,7 @@
             <%= i %>
             </td>
             <td>
-              <%= link_to(aws_text.title, aws_text, target: :_blank, rel: :noopener) %>
+              <%= link_to(aws_text.title, aws_text, target: :_blank, rel: "noopener") %>
             </td>
           </tr>
         <% end %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -20,7 +20,7 @@
             <%= i %>
             </td>
             <td>
-              <%= link_to(aws_text.title, aws_text, target: :_blank) %>
+              <%= link_to(aws_text.title, aws_text, target: :_blank, rel: :noopener) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -20,7 +20,7 @@
             <%= i %>
             </td>
             <td>
-              <%= link_to(aws_text.title, aws_text) %>
+              <%= link_to(aws_text.title, aws_text, target: :_blank) %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
## 内容

- AWS教材リンクを新規ウインドウで開く

### 参考資料

- [stackoverflow Rails: Open link in new tab (with 'link_to')
](https://stackoverflow.com/questions/12133894/rails-open-link-in-new-tab-with-link-to)